### PR TITLE
PII suppresion in step messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,9 +182,9 @@
       }
     },
     "@run-crank/utilities": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.0.tgz",
-      "integrity": "sha512-gEDbF8hl99dFtg3kN7hEnM4E82RAnX3+8HATXbPWiVIr7zop5SDIL6mlk/QxpHecOlYgM4jebHJ+dqCTdotqVg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.1.tgz",
+      "integrity": "sha512-U9YS6zsu7/PCtJl6/PZRcnS8Dh3r4CWLyAg01MhUp7e5rkW2OXZUdosO0RcRYfQHWjs6flz8R2ATTo7TD/jsrQ==",
       "requires": {
         "csv-string": "^4.0.1",
         "moment": "^2.24.0"
@@ -1378,9 +1378,9 @@
       }
     },
     "csv-string": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.0.tgz",
-      "integrity": "sha512-67UM45fosQvvh+HUvC8iNgg2B4UHWJ5Qud7TWy1EcbIQ9levAFKWudMk2k8U3LgXZP/Drr6eBwBwbSWq2N8HZA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+      "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ=="
     },
     "data-uri-to-buffer": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@run-crank/utilities": "^0.5.0",
+    "@run-crank/utilities": "^0.5.1",
     "axios": "^0.21.1",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.24.3",

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -87,8 +87,8 @@ export abstract class BaseStep {
     return stepDefinition;
   }
 
-  assert(operator: string, actualValue: string, value: string, field: string): util.AssertionResult {
-    return util.assert(operator, actualValue, value, field);
+  assert(operator: string, actualValue: string, value: string, field: string, piiLevel: string = null): util.AssertionResult {
+    return util.assert(operator, actualValue, value, field, piiLevel);
   }
 
   protected pass(message: string, messageArgs: any[] = [], records: StepRecord[] = []): RunStepResponse {

--- a/src/steps/accounts/account-field-equals.ts
+++ b/src/steps/accounts/account-field-equals.ts
@@ -104,7 +104,7 @@ export class AccountFieldEqualsStep extends BaseStep implements StepInterface {
       if (this.listFields.includes(field) && operator.toLowerCase() === 'be') {
         const records = this.createRecords(accounts[0], stepData['__stepOrder']);
         if (accounts[0].attributes[field].includes(expectation)) {
-          const result = this.assert(operator, expectation, expectation, field);
+          const result = this.assert(operator, expectation, expectation, field, stepData['__piiSuppressionLevel']);
           return this.pass(result.message, [], records);
         }
       }
@@ -123,7 +123,7 @@ export class AccountFieldEqualsStep extends BaseStep implements StepInterface {
       }
 
       const records = this.createRecords(accounts[0], stepData['__stepOrder']);
-      const result = this.assert(operator, actual, expectation, field);
+      const result = this.assert(operator, actual, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);

--- a/src/steps/prospects/prospect-field-equals.ts
+++ b/src/steps/prospects/prospect-field-equals.ts
@@ -92,7 +92,7 @@ export class ProspectFieldEqualsStep extends BaseStep implements StepInterface {
         const records = this.createRecords(prospect, stepData['__stepOrder']);
         if (operator.toLowerCase() === 'be') {
           if (prospect.attributes[field].includes(expectation)) {
-            const result = this.assert(operator, expectation, expectation, field);
+            const result = this.assert(operator, expectation, expectation, field, stepData['__piiSuppressionLevel']);
             return this.pass(result.message, [], records);
           }
         }
@@ -112,7 +112,7 @@ export class ProspectFieldEqualsStep extends BaseStep implements StepInterface {
       }
 
       const records = this.createRecords(prospect, stepData['__stepOrder']);
-      const result = this.assert(operator, actual, expectation, field);
+      const result = this.assert(operator, actual, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);


### PR DESCRIPTION
- Update typescript cog utilities
- Some step messages will have PII removed if a "__piiSuppressionLevel" is passed in the stepData